### PR TITLE
Migrate Actions workflows to new cluster

### DIFF
--- a/.github/workflows/flow-pull-request-checks.yaml
+++ b/.github/workflows/flow-pull-request-checks.yaml
@@ -7,11 +7,11 @@ on:
         type: string
         required: false
         default: "v0.30.0"
-#  pull_request:
-#    types:
-#      - opened
-#      - reopened
-#      - synchronize
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
 
 
 concurrency:

--- a/.github/workflows/zxc-build-library.yaml
+++ b/.github/workflows/zxc-build-library.yaml
@@ -45,7 +45,7 @@ jobs:
           fi
           
           [[ "${HAPI_VERSION}" == v* ]] || HAPI_VERSION="v${HAPI_VERSION}"
-          echo "::set-output name=number::${HAPI_VERSION}"
+          echo "number=${HAPI_VERSION}" >> "${GITHUB_OUTPUT}"
 
   build:
     name: Build
@@ -71,6 +71,12 @@ jobs:
         with:
           submodules: true
 
+      - name: Install Linux Prerequisites
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config
+
       - name: Install CMake & Ninja
         uses: lukka/get-cmake@latest
 
@@ -91,7 +97,7 @@ jobs:
 
       - name: Compute Short SHA
         id: sha
-        run: echo "::set-output name=short::$(echo -n "${{ github.sha }}" | cut -c1-8)"
+        run: echo "short=$(echo -n "${{ github.sha }}" | cut -c1-8)" >> "${GITHUB_OUTPUT}"
 
       - name: Attach Artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/zxc-build-library.yaml
+++ b/.github/workflows/zxc-build-library.yaml
@@ -49,7 +49,11 @@ jobs:
 
   build:
     name: Build
-    runs-on: [self-hosted, ${{ matrix.os }}, xlarge, ephemeral]
+    runs-on:
+      - self-hosted
+      - "${{ matrix.os }}"
+      - xlarge
+      - ephemeral
     strategy:
       matrix:
         include:

--- a/.github/workflows/zxc-build-library.yaml
+++ b/.github/workflows/zxc-build-library.yaml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   hapi-version:
     name: Version Check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, xlarge, ephemeral]
     outputs:
       tag: ${{ steps.version.outputs.tag }}
     steps:
@@ -49,11 +49,11 @@ jobs:
 
   build:
     name: Build
-    runs-on: ${{ matrix.os }}
+    runs-on: [self-hosted, ${{ matrix.os }}, xlarge, ephemeral]
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: Linux
             preset: linux-x64
 #          - os: macos-latest
 #            preset: macos-x64
@@ -76,11 +76,11 @@ jobs:
       - name: Setup VCPkg
         uses: lukka/run-vcpkg@v10
 
-#      - name: CMake Build (Debug)
-#        uses: lukka/run-cmake@v10
-#        with:
-#          configurePreset: ${{ matrix.preset }}
-#          buildPreset: ${{ matrix.preset }}-debug
+      - name: CMake Build (Debug)
+        uses: lukka/run-cmake@v10
+        with:
+          configurePreset: ${{ matrix.preset }}
+          buildPreset: ${{ matrix.preset }}-debug
 
       - name: CMake Build (Release)
         uses: lukka/run-cmake@v10

--- a/.github/workflows/zxc-build-library.yaml
+++ b/.github/workflows/zxc-build-library.yaml
@@ -71,9 +71,6 @@ jobs:
         with:
           submodules: true
 
-      - name: Fixup VCPkg Triplets
-        run: echo "set(VCPKG_BUILD_TYPE release)" | tee -a vcpkg/triplets/x64-windows-static.cmake
-
       - name: Install CMake & Ninja
         uses: lukka/get-cmake@latest
 
@@ -83,7 +80,7 @@ jobs:
       - name: CMake Build (Debug)
         uses: lukka/run-cmake@v10
         with:
-          configurePreset: ${{ matrix.preset }}
+          configurePreset: ${{ matrix.preset }}-debug
           buildPreset: ${{ matrix.preset }}-debug
 
       - name: CMake Build (Release)

--- a/.github/workflows/zxc-build-library.yaml
+++ b/.github/workflows/zxc-build-library.yaml
@@ -75,7 +75,7 @@ jobs:
         if: ${{ runner.os == 'Linux' }}
         run: |
           sudo apt-get update
-          sudo apt-get install -y pkg-config
+          sudo apt-get install -y pkg-config linux-headers-gke-5.15
 
       - name: Install CMake & Ninja
         uses: lukka/get-cmake@latest

--- a/.github/workflows/zxc-build-library.yaml
+++ b/.github/workflows/zxc-build-library.yaml
@@ -82,6 +82,8 @@ jobs:
 
       - name: Setup VCPkg
         uses: lukka/run-vcpkg@v10
+        with:
+          binaryCachePath: ${{ github.workspace }}/b/vcpkg_cache
 
       - name: CMake Build (Debug)
         uses: lukka/run-cmake@v10

--- a/.github/workflows/zxc-build-library.yaml
+++ b/.github/workflows/zxc-build-library.yaml
@@ -77,6 +77,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y pkg-config linux-headers-5.15.0-56-generic
 
+      - name: Ensure Binary Cache Path Exists
+        run: mkdir -p "${{ github.workspace }}/b/vcpkg_cache"
+
       - name: Install CMake & Ninja
         uses: lukka/get-cmake@latest
 

--- a/.github/workflows/zxc-build-library.yaml
+++ b/.github/workflows/zxc-build-library.yaml
@@ -75,7 +75,7 @@ jobs:
         if: ${{ runner.os == 'Linux' }}
         run: |
           sudo apt-get update
-          sudo apt-get install -y pkg-config linux-headers-gke-5.15
+          sudo apt-get install -y pkg-config linux-headers-5.15.0-56-generic
 
       - name: Install CMake & Ninja
         uses: lukka/get-cmake@latest

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -19,10 +19,6 @@
           "type": "FILEPATH",
           "value": "${sourceDir}/vcpkg/scripts/buildsystems/vcpkg.cmake"
         },
-        "CMAKE_BUILD_TYPE": {
-          "type": "STRING",
-          "value": "Release"
-        },
         "HAPI_VERSION_TAG": {
           "type": "STRING",
           "value": "$env{HAPI_VERSION_TAG}"
@@ -42,10 +38,6 @@
           "type": "FILEPATH",
           "value": "${sourceDir}/vcpkg/scripts/buildsystems/vcpkg.cmake"
         },
-        "CMAKE_BUILD_TYPE": {
-          "type": "STRING",
-          "value": "Release"
-        },
         "HAPI_VERSION_TAG": {
           "type": "STRING",
           "value": "$env{HAPI_VERSION_TAG}"
@@ -59,6 +51,24 @@
         "VCPKG_TARGET_TRIPLET": {
           "type": "STRING",
           "value": "x64-linux"
+        },
+        "CMAKE_BUILD_TYPE": {
+          "type": "STRING",
+          "value": "Release"
+        }
+      }
+    },
+    {
+      "name": "linux-x64-debug",
+      "inherits": ["vcpkg-base"],
+      "cacheVariables": {
+        "VCPKG_TARGET_TRIPLET": {
+          "type": "STRING",
+          "value": "x64-linux"
+        },
+        "CMAKE_BUILD_TYPE": {
+          "type": "STRING",
+          "value": "Debug"
         }
       }
     },
@@ -69,6 +79,24 @@
         "VCPKG_TARGET_TRIPLET": {
           "type": "STRING",
           "value": "x64-osx"
+        },
+        "CMAKE_BUILD_TYPE": {
+          "type": "STRING",
+          "value": "Release"
+        }
+      }
+    },
+    {
+      "name": "macos-x64-debug",
+      "inherits": ["vcpkg-base"],
+      "cacheVariables": {
+        "VCPKG_TARGET_TRIPLET": {
+          "type": "STRING",
+          "value": "x64-osx"
+        },
+        "CMAKE_BUILD_TYPE": {
+          "type": "STRING",
+          "value": "Debug"
         }
       }
     },
@@ -79,6 +107,24 @@
         "VCPKG_TARGET_TRIPLET": {
           "type": "STRING",
           "value": "arm64-osx"
+        },
+        "CMAKE_BUILD_TYPE": {
+          "type": "STRING",
+          "value": "Release"
+        }
+      }
+    },
+    {
+      "name": "macos-arm64-debug",
+      "inherits": ["vcpkg-base"],
+      "cacheVariables": {
+        "VCPKG_TARGET_TRIPLET": {
+          "type": "STRING",
+          "value": "arm64-osx"
+        },
+        "CMAKE_BUILD_TYPE": {
+          "type": "STRING",
+          "value": "Debug"
         }
       }
     },
@@ -89,6 +135,24 @@
         "VCPKG_TARGET_TRIPLET": {
           "type": "STRING",
           "value": "x64-windows"
+        },
+        "CMAKE_BUILD_TYPE": {
+          "type": "STRING",
+          "value": "Release"
+        }
+      }
+    },
+    {
+      "name": "windows-x64-debug",
+      "inherits": ["vcpkg-msbuild-base"],
+      "cacheVariables": {
+        "VCPKG_TARGET_TRIPLET": {
+          "type": "STRING",
+          "value": "x64-windows"
+        },
+        "CMAKE_BUILD_TYPE": {
+          "type": "STRING",
+          "value": "Debug"
         }
       }
     }
@@ -103,11 +167,27 @@
       "targets": ["install"]
     },
     {
+      "name": "linux-x64-debug",
+      "configurePreset": "linux-x64-debug",
+      "displayName": "Build ninja-multi-vcpkg",
+      "description": "Build ninja-multi-vcpkg Configurations",
+      "configuration": "Debug",
+      "targets": ["install"]
+    },
+    {
       "name": "macos-x64-release",
       "configurePreset": "macos-x64-release",
       "displayName": "Build ninja-multi-vcpkg",
       "description": "Build ninja-multi-vcpkg Configurations",
       "configuration": "Release",
+      "targets": ["install"]
+    },
+    {
+      "name": "macos-x64-debug",
+      "configurePreset": "macos-x64-debug",
+      "displayName": "Build ninja-multi-vcpkg",
+      "description": "Build ninja-multi-vcpkg Configurations",
+      "configuration": "Debug",
       "targets": ["install"]
     },
     {
@@ -119,11 +199,27 @@
       "targets": ["install"]
     },
     {
+      "name": "macos-arm64-debug",
+      "configurePreset": "macos-arm64-debug",
+      "displayName": "Build ninja-multi-vcpkg",
+      "description": "Build ninja-multi-vcpkg Configurations",
+      "configuration": "Debug",
+      "targets": ["install"]
+    },
+    {
       "name": "windows-x64-release",
       "configurePreset": "windows-x64-release",
       "displayName": "MSVC Release (x64)",
       "description": "Build MSVC Configurations",
       "configuration": "Release",
+      "targets": ["install"]
+    },
+    {
+      "name": "windows-x64-debug",
+      "configurePreset": "windows-x64-debug",
+      "displayName": "MSVC Debug (x64)",
+      "description": "Build MSVC Configurations",
+      "configuration": "Debug",
       "targets": ["install"]
     }
   ],


### PR DESCRIPTION
## Description

Updates the workflows to use the new ARC cluster and fixes remaining deprecation warnings due to `set-output` usage in the steps.

### Related Issues 

- Closes #5 