### PR TITLE
Build OpenSSL from source

### DIFF
--- a/BuildOpenSSL.cmake
+++ b/BuildOpenSSL.cmake
@@ -1,0 +1,50 @@
+include(ExternalProject)
+set(OPENSSL_SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/_deps/openssl-src) # default path by CMake
+set(OPENSSL_INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/openssl)
+set(OPENSSL_INCLUDE_DIR ${OPENSSL_INSTALL_DIR}/include)
+
+if (WIN32)
+    set(OPENSSL_CONFIGURE_COMMAND perl ${OPENSSL_SOURCE_DIR}/Configure VC-WIN64A)
+    set(OPENSSL_BUILD_COMMAND nmake /S)
+    set(OPENSSL_INSTALL_COMMAND nmake install /S)
+    set(OPENSSL_LIBRARY_EXTENSION .lib)
+else ()
+    set(OPENSSL_CONFIGURE_COMMAND ${OPENSSL_SOURCE_DIR}/Configure)
+    set(OPENSSL_BUILD_COMMAND make)
+    set(OPENSSL_INSTALL_COMMAND make install)
+    set(OPENSSL_LIBRARY_EXTENSION .a)
+endif ()
+
+if (LINUX)
+    set(OPENSSL_BYPRODUCT_DIR ${OPENSSL_INSTALL_DIR}/lib64)
+else ()
+    set(OPENSSL_BYPRODUCT_DIR ${OPENSSL_INSTALL_DIR}/lib)
+endif ()
+
+ExternalProject_Add(OpenSSL
+        SOURCE_DIR ${OPENSSL_SOURCE_DIR}
+        GIT_REPOSITORY https://github.com/openssl/openssl.git
+        GIT_TAG master
+        USES_TERMINAL_DOWNLOAD TRUE
+        CONFIGURE_COMMAND ${OPENSSL_CONFIGURE_COMMAND} --prefix=${OPENSSL_INSTALL_DIR} --openssldir=${OPENSSL_INSTALL_DIR}
+        BUILD_COMMAND ${OPENSSL_BUILD_COMMAND}
+        TEST_COMMAND ""
+        INSTALL_COMMAND ${OPENSSL_INSTALL_COMMAND}
+        INSTALL_DIR ${OPENSSL_INSTALL_DIR}
+        BUILD_BYPRODUCTS ${OPENSSL_BYPRODUCT_DIR}/libcrypto${OPENSSL_LIBRARY_EXTENSION} ${OPENSSL_BYPRODUCT_DIR}/libssl${OPENSSL_LIBRARY_EXTENSION}
+        UPDATE_COMMAND ""
+        )
+
+# We cannot use find_library because ExternalProject_Add() is performed at build time.
+# And to please the property INTERFACE_INCLUDE_DIRECTORIES, we make the include directory in advance.
+file(MAKE_DIRECTORY ${OPENSSL_INCLUDE_DIR})
+
+add_library(OpenSSL::Crypto STATIC IMPORTED GLOBAL)
+set_property(TARGET OpenSSL::Crypto PROPERTY IMPORTED_LOCATION ${OPENSSL_BYPRODUCT_DIR}/libcrypto${OPENSSL_LIBRARY_EXTENSION})
+set_property(TARGET OpenSSL::Crypto PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${OPENSSL_INCLUDE_DIR})
+add_dependencies(OpenSSL::Crypto OpenSSL)
+
+add_library(OpenSSL::SSL STATIC IMPORTED GLOBAL)
+set_property(TARGET OpenSSL::SSL PROPERTY IMPORTED_LOCATION ${OPENSSL_BYPRODUCT_DIR}/libssl${OPENSSL_LIBRARY_EXTENSION})
+set_property(TARGET OpenSSL::SSL PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${OPENSSL_INCLUDE_DIR})
+add_dependencies(OpenSSL::SSL OpenSSL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.21...3.24)
 project(hedera-protobufs-cpp VERSION 0.1.0 DESCRIPTION "Hedera C++ Protobuf Library" LANGUAGES CXX)
 
-set (CMAKE_CXX_STANDARD 20)
-set (CMAKE_CXX_STANDARD_REQUIRED 14)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX}/${CMAKE_BUILD_TYPE}/${CMAKE_HOST_SYSTEM_NAME}/${CMAKE_HOST_SYSTEM_PROCESSOR})
 
@@ -10,8 +10,10 @@ include(FetchContent)
 
 set(Protobuf_USE_STATIC_LIBS ON)
 
+include(BuildOpenSSL.cmake)
+set(gRPC_SSL_PROVIDER package)
+
 find_package(ZLIB REQUIRED)
-find_package(OpenSSL REQUIRED)
 find_package(Protobuf REQUIRED)
 find_package(gRPC CONFIG REQUIRED)
 find_package(re2 CONFIG REQUIRED)
@@ -20,15 +22,15 @@ find_package(absl CONFIG REQUIRED)
 
 set(HAPI_VERSION_TAG "v0.30.0" CACHE STRING "Use the configured version tag for the Hedera API protobufs")
 
-if(HAPI_VERSION_TAG STREQUAL "")
+if (HAPI_VERSION_TAG STREQUAL "")
     set(HAPI_VERSION_TAG "v0.30.0")
-endif()
+endif ()
 
 # Fetch the protobuf definitions
 FetchContent_Declare(
         HProto
-        GIT_REPOSITORY  https://github.com/hashgraph/hedera-protobufs.git
-        GIT_TAG         ${HAPI_VERSION_TAG}
+        GIT_REPOSITORY https://github.com/hashgraph/hedera-protobufs.git
+        GIT_TAG ${HAPI_VERSION_TAG}
 )
 set(FETCHCONTENT_QUIET OFF)
 FetchContent_MakeAvailable(HProto)
@@ -36,9 +38,9 @@ FetchContent_MakeAvailable(HProto)
 # Clean and update the protobuf definitions
 set(PROTO_SRC ${PROJECT_SOURCE_DIR}/src/proto)
 file(GLOB_RECURSE PROTO_FILES ${PROTO_SRC}/*.proto)
-if(PROTO_FILES)
+if (PROTO_FILES)
     file(REMOVE ${PROTO_FILES})
-endif()
+endif ()
 file(INSTALL ${hproto_SOURCE_DIR}/services/ DESTINATION ${PROTO_SRC})
 
 add_subdirectory(src)

--- a/src/proto/CMakeLists.txt
+++ b/src/proto/CMakeLists.txt
@@ -102,7 +102,7 @@ set(PROTO_FILES
 # End Protobuf Definitions
 
 add_library(hapi STATIC ${PROTO_FILES})
-target_link_libraries(hapi PRIVATE protobuf::libprotobuf gRPC::grpc gRPC::grpc++)
+target_link_libraries(hapi PRIVATE protobuf::libprotobuf gRPC::grpc gRPC::grpc++ OpenSSL::SSL OpenSSL::Crypto)
 target_include_directories(hapi PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 #

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -3,7 +3,6 @@
   "version-string": "0.30.0",
   "dependencies": [
     "zlib",
-    "openssl",
     "protobuf",
     "grpc",
     "upb"


### PR DESCRIPTION
**Description**:
This PR incorporates the same changes as the [Hedera C++ SDK](https://github.com/hashgraph/hedera-sdk-cpp/pull/162). It pulls in `master` OpenSSL and builds and links to gRPC so that versions can be consistent.

**Related issue(s)**:

Fixes #7 

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
