### PR TITLE
Upgrade to v0.35 of Hedera protobufs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,10 +20,10 @@ find_package(re2 CONFIG REQUIRED)
 find_package(c-ares CONFIG REQUIRED)
 find_package(absl CONFIG REQUIRED)
 
-set(HAPI_VERSION_TAG "v0.34.0" CACHE STRING "Use the configured version tag for the Hedera API protobufs")
+set(HAPI_VERSION_TAG "v0.35.0" CACHE STRING "Use the configured version tag for the Hedera API protobufs")
 
 if (HAPI_VERSION_TAG STREQUAL "")
-    set(HAPI_VERSION_TAG "v0.34.0")
+    set(HAPI_VERSION_TAG "v0.35.0")
 endif ()
 
 # Fetch the protobuf definitions


### PR DESCRIPTION
**Description**:
This PR updates the C++ protobufs to v0.35 of the Hedera protobufs.

**Related issue(s)**:

Fixes #16 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
