### PR TITLE
Upgrade to `v0.40.0` of Hedera protobufs

### DIFF
--- a/.github/workflows/zxc-build-library.yaml
+++ b/.github/workflows/zxc-build-library.yaml
@@ -75,7 +75,7 @@ jobs:
         if: ${{ runner.os == 'Linux' }}
         run: |
           sudo apt-get update
-          sudo apt-get install -y pkg-config linux-headers-5.15.0-1032-gke build-essential
+          sudo apt-get install -y pkg-config linux-headers-5.15.0-76-generic build-essential
 
       - name: Ensure Binary Cache Path Exists
         run: mkdir -p "${{ github.workspace }}/b/vcpkg_cache"

--- a/.github/workflows/zxc-build-library.yaml
+++ b/.github/workflows/zxc-build-library.yaml
@@ -75,7 +75,8 @@ jobs:
         if: ${{ runner.os == 'Linux' }}
         run: |
           sudo apt-get update
-          sudo apt-get install -y pkg-config linux-headers-5.15.0-56-generic build-essential
+          sudo apt-get install -y linux-headers-`uname -r`
+#          sudo apt-get install -y pkg-config linux-headers-5.15.0-76-generic build-essential
 
       - name: Ensure Binary Cache Path Exists
         run: mkdir -p "${{ github.workspace }}/b/vcpkg_cache"

--- a/.github/workflows/zxc-build-library.yaml
+++ b/.github/workflows/zxc-build-library.yaml
@@ -75,8 +75,7 @@ jobs:
         if: ${{ runner.os == 'Linux' }}
         run: |
           sudo apt-get update
-          sudo apt-get install -y linux-headers-`uname -r`
-#          sudo apt-get install -y pkg-config linux-headers-5.15.0-76-generic build-essential
+          sudo apt-get install -y pkg-config linux-headers-5.15.0-1032-gke build-essential
 
       - name: Ensure Binary Cache Path Exists
         run: mkdir -p "${{ github.workspace }}/b/vcpkg_cache"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,10 +20,10 @@ find_package(re2 CONFIG REQUIRED)
 find_package(c-ares CONFIG REQUIRED)
 find_package(absl CONFIG REQUIRED)
 
-set(HAPI_VERSION_TAG "v0.39.0" CACHE STRING "Use the configured version tag for the Hedera API protobufs")
+set(HAPI_VERSION_TAG "v0.40.0" CACHE STRING "Use the configured version tag for the Hedera API protobufs")
 
 if (HAPI_VERSION_TAG STREQUAL "")
-    set(HAPI_VERSION_TAG "v0.39.0")
+    set(HAPI_VERSION_TAG "v0.40.0")
 endif ()
 
 # Fetch the protobuf definitions

--- a/src/proto/CMakeLists.txt
+++ b/src/proto/CMakeLists.txt
@@ -20,6 +20,7 @@ set(PROTO_FILES
         contract_get_records.proto
         contract_state_change.proto
         contract_update.proto
+        contract_types.proto
         crypto_add_live_hash.proto
         crypto_approve_allowance.proto
         crypto_create.proto


### PR DESCRIPTION
**Description**:

This PR upgrades the C++ protobufs to `v0.40.0` of the Hedera protobufs. 

**Related issue(s)**:

**Fixes:** https://github.com/hashgraph/hedera-protobufs-cpp/issues/24

**Notes for reviewer**:


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
