### PR TITLE
Add mirror node protobufs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -883,6 +883,7 @@ secring.*
 
 ### Ignore Generated Source
 src/proto/*.proto
+src/proto/mirror/*.proto
 src/proto/state
 
 ### Ignore Generated Package Files

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ if (PROTO_FILES)
     file(REMOVE ${PROTO_FILES})
 endif ()
 
+file(INSTALL ${hproto_SOURCE_DIR}/mirror/ DESTINATION ${PROTO_SRC}/mirror)
 file(INSTALL ${hproto_SOURCE_DIR}/services/ DESTINATION ${PROTO_SRC})
 file(INSTALL ${hproto_SOURCE_DIR}/sdk/ DESTINATION ${PROTO_SRC})
 

--- a/src/proto/CMakeLists.txt
+++ b/src/proto/CMakeLists.txt
@@ -100,7 +100,10 @@ set(PROTO_FILES
         transaction_response.proto
         unchecked_submit.proto
         util_prng.proto
-        util_service.proto)
+        util_service.proto
+
+        mirror/consensus_service.proto
+        mirror/mirror_network_service.proto)
 # End Protobuf Definitions
 
 add_library(hapi STATIC ${PROTO_FILES})
@@ -117,4 +120,3 @@ protobuf_generate(TARGET hapi LANGUAGE grpc GENERATE_EXTENSIONS .grpc.pb.h .grpc
 # Install Library & Headers
 install(TARGETS hapi ARCHIVE DESTINATION lib LIBRARY DESTINATION lib RUNTIME DESTINATION bin)
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} DESTINATION include FILES_MATCHING PATTERN "*.h")
-


### PR DESCRIPTION
**Description**:
This PR adds the mirror node protobufs so that the C++ SDK may communicate with the mirror nodes.

**Related issue(s)**:

Fixes #28 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
