### PR TITLE
Upgrade to `v0.41.0` of Hedera Protobufs (PR)

### DIFF
--- a/.github/workflows/zxc-build-library.yaml
+++ b/.github/workflows/zxc-build-library.yaml
@@ -75,7 +75,7 @@ jobs:
         if: ${{ runner.os == 'Linux' }}
         run: |
           sudo apt-get update
-          sudo apt-get install -y pkg-config linux-headers-5.15.0-76-generic build-essential
+          sudo apt-get install -y pkg-config linux-headers-5.15.0-79-generic build-essential
 
       - name: Ensure Binary Cache Path Exists
         run: mkdir -p "${{ github.workspace }}/b/vcpkg_cache"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,10 +20,10 @@ find_package(re2 CONFIG REQUIRED)
 find_package(c-ares CONFIG REQUIRED)
 find_package(absl CONFIG REQUIRED)
 
-set(HAPI_VERSION_TAG "v0.40.0" CACHE STRING "Use the configured version tag for the Hedera API protobufs")
+set(HAPI_VERSION_TAG "v0.41.0" CACHE STRING "Use the configured version tag for the Hedera API protobufs")
 
 if (HAPI_VERSION_TAG STREQUAL "")
-    set(HAPI_VERSION_TAG "v0.40.0")
+    set(HAPI_VERSION_TAG "v0.41.0")
 endif ()
 
 # Fetch the protobuf definitions


### PR DESCRIPTION
**Description**:

This PR upgrades the `Hedera C++ protobufs` to use `v0.41.0` of the `Hedera Protobufs API`.

**Related issue(s)**:

**Fixes:** https://github.com/hashgraph/hedera-protobufs-cpp/issues/30

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
