### PR TITLE
Workflow optimisations for PR Checks action (PR)

### DIFF
--- a/.github/workflows/flow-pull-request-checks.yaml
+++ b/.github/workflows/flow-pull-request-checks.yaml
@@ -12,6 +12,7 @@ on:
       - opened
       - reopened
       - synchronize
+      - closed
 
 
 concurrency:

--- a/.github/workflows/zxc-build-library.yaml
+++ b/.github/workflows/zxc-build-library.yaml
@@ -95,6 +95,7 @@ jobs:
           buildPreset: ${{ matrix.preset }}-debug
 
       - name: CMake Build (Release)
+        if: github.event.pull_request.merged == true
         uses: lukka/run-cmake@v10
         with:
           configurePreset: ${{ matrix.preset }}-release
@@ -105,6 +106,7 @@ jobs:
         run: echo "short=$(echo -n "${{ github.sha }}" | cut -c1-8)" >> "${GITHUB_OUTPUT}"
 
       - name: Attach Artifact
+        if: github.event.pull_request.merged == true
         uses: actions/upload-artifact@v3
         with:
           name: hapi-library-${{ runner.os }}-${{ steps.sha.outputs.short }}


### PR DESCRIPTION
**Description**:

This PR introduces some optimisations for the GitHub Action of `PR Checks`. The following steps will be skipped during the PR process:
 - `CMake Build (Release)`
 - `Attach Artifact`

Once the PR has been merged into `main`, the same `Action` should be executed again, but then all of the steps will be passed.

**Related issue(s)**:

**Fixes:** https://github.com/hashgraph/hedera-protobufs-cpp/issues/32

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
