### PR TITLE
Upgrade to `v0.43.0` of Hedera protobufs (PR)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,10 +20,10 @@ find_package(re2 CONFIG REQUIRED)
 find_package(c-ares CONFIG REQUIRED)
 find_package(absl CONFIG REQUIRED)
 
-set(HAPI_VERSION_TAG "v0.42.0" CACHE STRING "Use the configured version tag for the Hedera API protobufs")
+set(HAPI_VERSION_TAG "v0.43.0" CACHE STRING "Use the configured version tag for the Hedera API protobufs")
 
 if (HAPI_VERSION_TAG STREQUAL "")
-    set(HAPI_VERSION_TAG "v0.42.0")
+    set(HAPI_VERSION_TAG "v0.43.0")
 endif ()
 
 # Fetch the protobuf definitions


### PR DESCRIPTION
**Description**:

This PR upgrades the `Hedera C++ Protobufs` to use `v0.43.0` of the `Hedera Protobufs API`.

**Related issue(s)**:

**Fixes**: https://github.com/hashgraph/hedera-protobufs-cpp/issues/36

**Notes for reviewer**:

This PR is just a preparation for upgrading the `Hedera C++ Protobufs` API to the latest available version. 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
