### PR TITLE
chore: Upgrade Hedera Protobufs to v0.48.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.21...3.24)
-project(hedera-protobufs-cpp VERSION 0.47.0 DESCRIPTION "Hedera C++ Protobuf Library" LANGUAGES CXX)
+project(hedera-protobufs-cpp VERSION 0.48.1 DESCRIPTION "Hedera C++ Protobuf Library" LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -20,10 +20,10 @@ find_package(re2 CONFIG REQUIRED)
 find_package(c-ares CONFIG REQUIRED)
 find_package(absl CONFIG REQUIRED)
 
-set(HAPI_VERSION_TAG "v0.47.0" CACHE STRING "Use the configured version tag for the Hedera API protobufs")
+set(HAPI_VERSION_TAG "v0.48.1" CACHE STRING "Use the configured version tag for the Hedera API protobufs")
 
 if (HAPI_VERSION_TAG STREQUAL "")
-    set(HAPI_VERSION_TAG "v0.47.0")
+    set(HAPI_VERSION_TAG "v0.48.1")
 endif ()
 
 # Fetch the protobuf definitions

--- a/src/proto/CMakeLists.txt
+++ b/src/proto/CMakeLists.txt
@@ -87,6 +87,8 @@ set(PROTO_FILES
         token_unfreeze_account.proto
         token_unpause.proto
         token_update.proto
+        token_update_nft.proto
+        token_update_nfts.proto
         token_wipe_account.proto
         transaction.proto
         transaction_body.proto


### PR DESCRIPTION
**Description**:
This PR upgrades the Hedera C++ Protobufs to use `v0.48.1` of the Hedera Protobufs API.

**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-protobufs-cpp/issues/44

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
