### PR TITLE
chore: Upgrade Hedera Protobufs to v0.49.0-alpha0

### DIFF
--- a/.github/workflows/zxc-build-library.yaml
+++ b/.github/workflows/zxc-build-library.yaml
@@ -81,7 +81,7 @@ jobs:
         run: mkdir -p "${{ github.workspace }}/b/vcpkg_cache"
 
       - name: Install CMake & Ninja
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@v3.27.7
 
       - name: Setup VCPkg
         uses: lukka/run-vcpkg@v10

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.21...3.24)
-project(hedera-protobufs-cpp VERSION 0.48.1 DESCRIPTION "Hedera C++ Protobuf Library" LANGUAGES CXX)
+project(hedera-protobufs-cpp VERSION 0.49.0 DESCRIPTION "Hedera C++ Protobuf Library" LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -20,10 +20,10 @@ find_package(re2 CONFIG REQUIRED)
 find_package(c-ares CONFIG REQUIRED)
 find_package(absl CONFIG REQUIRED)
 
-set(HAPI_VERSION_TAG "v0.48.1" CACHE STRING "Use the configured version tag for the Hedera API protobufs")
+set(HAPI_VERSION_TAG "v0.49.0-alpha.0" CACHE STRING "Use the configured version tag for the Hedera API protobufs")
 
 if (HAPI_VERSION_TAG STREQUAL "")
-    set(HAPI_VERSION_TAG "v0.48.1")
+    set(HAPI_VERSION_TAG "v0.49.0-alpha.0")
 endif ()
 
 # Fetch the protobuf definitions

--- a/src/proto/CMakeLists.txt
+++ b/src/proto/CMakeLists.txt
@@ -87,7 +87,6 @@ set(PROTO_FILES
         token_unfreeze_account.proto
         token_unpause.proto
         token_update.proto
-        token_update_nft.proto
         token_update_nfts.proto
         token_wipe_account.proto
         transaction.proto

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,27 +1,11 @@
 {
   "name": "hedera-protobufs-cpp",
   "version-string": "0.1.0",
-  "builtin-baseline": "680071397677bb123b2f2b0ebe73905feae4a955",
   "dependencies": [
-    {
-      "name": "openssl",
-      "version>=": "3.2.0#2"
-    },
-    {
-      "name": "zlib",
-      "version>=": "1.2.12"
-    },
-    {
-      "name": "protobuf",
-      "version>=": "3.21.6"
-    },
-    {
-      "name": "grpc",
-      "version>=": "1.49.0"
-    },
-    {
-      "name": "upb",
-      "version>=": "2022-06-21"
-    }
-  ]
+     "openssl",
+     "zlib",
+     "protobuf",
+     "grpc",
+     "upb"
+  ] 
 }


### PR DESCRIPTION
**Description**:
This PR upgrades the Hedera C++ Protobufs to use `v0.49.0-alpha0` of the Hedera Protobufs API.

**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-protobufs-cpp/issues/46

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
