### PR TITLE
chore: Update branch name for Android builds

### DIFF
--- a/.github/workflows/zxc-build-library.yaml
+++ b/.github/workflows/zxc-build-library.yaml
@@ -83,7 +83,7 @@ jobs:
       - name: CMake Android Build
         if: github.event.pull_request.merged == true
         run: |
-          docker build -t ubuntu-jammy-hedera-protobufs-cpp-android-build . --build-arg BRANCH_NAME=${{ github.head_ref }}
+          docker build -t ubuntu-jammy-hedera-protobufs-cpp-android-build . --build-arg BRANCH_NAME=${{ github.base_ref }}
           docker cp $(docker create ubuntu-jammy-hedera-protobufs-cpp-android-build:latest):/hedera-protobufs-cpp/package .
 
       - name: Install CMake & Ninja


### PR DESCRIPTION
**Description**:
The previous PR for this issue #48 added Android builds when a pull request was merged. However, that was broken and the wrong branch name was being used. This should fix that issue.

**Related issue(s)**:

Fixes #42 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
