### PR TITLE
chore: Upgrade proto version to latest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.21...3.24)
-project(hedera-protobufs-cpp VERSION 0.50.0 DESCRIPTION "Hedera C++ Protobuf Library" LANGUAGES CXX)
+project(hedera-protobufs-cpp VERSION 0.52.0 DESCRIPTION "Hedera C++ Protobuf Library" LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -19,10 +19,10 @@ find_package(re2 CONFIG REQUIRED)
 find_package(c-ares CONFIG REQUIRED)
 find_package(absl CONFIG REQUIRED)
 
-set(HAPI_VERSION_TAG "v0.50.0" CACHE STRING "Use the configured version tag for the Hedera API protobufs")
+set(HAPI_VERSION_TAG "v0.52.0" CACHE STRING "Use the configured version tag for the Hedera API protobufs")
 
 if (HAPI_VERSION_TAG STREQUAL "")
-    set(HAPI_VERSION_TAG "v0.50.0")
+    set(HAPI_VERSION_TAG "v0.52.0")
 endif ()
 
 # Fetch the protobuf definitions

--- a/src/proto/CMakeLists.txt
+++ b/src/proto/CMakeLists.txt
@@ -51,7 +51,10 @@ set(PROTO_FILES
         network_get_execution_time.proto
         network_get_version_info.proto
         network_service.proto
+        node_create.proto
+        node_delete.proto
         node_stake_update.proto
+        node_update.proto
         query.proto
         query_header.proto
         response.proto
@@ -82,6 +85,7 @@ set(PROTO_FILES
         token_grant_kyc.proto
         token_mint.proto
         token_pause.proto
+        token_reject.proto
         token_revoke_kyc.proto
         token_service.proto
         token_unfreeze_account.proto


### PR DESCRIPTION
**Description**:
This PR upgrades the Hedera C++ Protobufs to use v0.52.0 of the Hedera Protobufs API.

**Introduced:**
* node_create.proto
* node_delete.proto
* node_update.proto
* token_reject.proto

**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-protobufs-cpp/issues/60

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
