### PR TITLE
chore: Upgrade Hedera Protobufs version to v0.54.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.21...3.24)
-project(hedera-protobufs-cpp VERSION 0.52.0 DESCRIPTION "Hedera C++ Protobuf Library" LANGUAGES CXX)
+project(hedera-protobufs-cpp VERSION 0.54.0 DESCRIPTION "Hedera C++ Protobuf Library" LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -19,10 +19,10 @@ find_package(re2 CONFIG REQUIRED)
 find_package(c-ares CONFIG REQUIRED)
 find_package(absl CONFIG REQUIRED)
 
-set(HAPI_VERSION_TAG "v0.52.0" CACHE STRING "Use the configured version tag for the Hedera API protobufs")
+set(HAPI_VERSION_TAG "v0.54.0" CACHE STRING "Use the configured version tag for the Hedera API protobufs")
 
 if (HAPI_VERSION_TAG STREQUAL "")
-    set(HAPI_VERSION_TAG "v0.52.0")
+    set(HAPI_VERSION_TAG "v0.54.0")
 endif ()
 
 # Fetch the protobuf definitions

--- a/src/proto/CMakeLists.txt
+++ b/src/proto/CMakeLists.txt
@@ -71,8 +71,11 @@ set(PROTO_FILES
         system_undelete.proto
         throttle_definitions.proto
         timestamp.proto
+        token_airdrop.proto
         token_associate.proto
         token_burn.proto
+        token_cancel_airdrop.proto
+        token_claim_airdrop.proto
         token_create.proto
         token_delete.proto
         token_dissociate.proto


### PR DESCRIPTION
**Description**:
This PR upgrades the Hedera C++ Protobufs to use v0.54.0 of the Hedera Protobufs API.

**Introduced:**
* token_airdrop.proto
* token_cancel_airdrop.proto
* token_claim_airdrop.proto

**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-protobufs-cpp/issues/72

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
